### PR TITLE
Create GitHub Releases with Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: GitHub Release Workflow
+
+on:
+  push:
+    tags:
+      # Semver-like tags "X.Y.Z"
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      # Parse version number from GITHUB_REF: "refs/tags/X.Y.Z" -> "X.Y.Z"
+      - name: Parse git tag
+        id: tag
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+      # Extract release notes for version "X.Y.Z"
+      - name: Extract release notes
+        run: make release-notes v=${{ steps.tag.outputs.VERSION }}
+      # Create GitHub Release for tag "X.Y.Z"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          # Default GitHub Actions token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.VERSION }}
+          release_name: ${{ steps.tag.outputs.VERSION }}
+          body_path: ./build/release/body.txt
+      # Add SOK-DGvX.Y.Z.html to the GitHub Release
+      - name: Upload HTML asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./releases/SOK-DGv${{ steps.tag.outputs.VERSION }}.html
+          asset_name: SOK-DGv${{ steps.tag.outputs.VERSION }}.html
+          asset_content_type: text/html
+      # Add SOK-DGvX.Y.Z.pdf to the GitHub Release
+      - name: Upload PDF asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./releases/SOK-DGv${{ steps.tag.outputs.VERSION }}.pdf
+          asset_name: SOK-DGv${{ steps.tag.outputs.VERSION }}.pdf
+          asset_content_type: application/pdf

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ build-html: pre-build ## Build HTML version of document
 		--number-sections
 	ln -sf SOK-DG${VERSION}.html releases/latest.html
 
+.PHONY: release-notes
+release-notes: ## Extract latest release notes for argument v=X.Y.Z
+	./scripts/release-notes.sh $(v)
+
 release:
 	git add CHANGELOG.md
 	git add src/DEVELOPMENT-GUIDELINES.md

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,4 +1,10 @@
-#! /usr/bin/env sh
+#!/bin/bash
+#
+# Extract release notes for a given version
+# from CHANGELOG.md to build/release/body.txt.
+# For example, "release-notes.sh 1.0.0"
+
+set -euo pipefail
 
 # The current version to search for
 version=$1
@@ -9,15 +15,15 @@ echo "Release notes for v${version}:"
 line=$(grep -n "\[v$version\]" CHANGELOG.md | cut -d : -f 1)
 
 # Remove everything up to the line with version (heading ##)
-without_header=$(tail -n +${line} < CHANGELOG.md)
+without_header=$(tail -n +"${line}" < CHANGELOG.md)
 
 # Current changelog block is only up to the next heading (##) line
-body=$(printf "$without_header" | tail -n +2 | sed '/^## /q' | sed '$d')
+body=$(printf "%s" "${without_header}" | tail -n +2 | sed '/^## /q' | sed '$d')
 
 # Make sure the directory exists
-mkdir -p build/release/
+mkdir -p build/release
 
-printf "${body}"
+printf "%s" "${body}"
 
 # Print body into file, to be consumed by GitHub Actions
-printf "${body}" > build/release/body.txt
+printf "%s" "${body}" > build/release/body.txt

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env sh
+
+# The current version to search for
+version=$1
+
+echo "Release notes for v${version}:"
+
+# Get the line number containing version input
+line=$(grep -n "\[v$version\]" CHANGELOG.md | cut -d : -f 1)
+
+# Remove everything up to the line with version (heading ##)
+without_header=$(tail -n +${line} < CHANGELOG.md)
+
+# Current changelog block is only up to the next heading (##) line
+body=$(printf "$without_header" | tail -n +2 | sed '/^## /q' | sed '$d')
+
+# Make sure the directory exists
+mkdir -p build/release/
+
+printf "${body}"
+
+# Print body into file, to be consumed by GitHub Actions
+printf "${body}" > build/release/body.txt


### PR DESCRIPTION
I like this idea of publishing a set of development guidelines, great work!

This PR adds a [GitHub Actions](https://github.com/features/actions) workflow for creating a [Release](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/about-releases) pointing to a newly-pushed semver tag _X.Y.Z_  (currently `1.8.0` at the time of this PR).

The workflow has a single job that runs the following steps:

1. Checkout the repo
1. Parse the current version number from the tag it's running against
1. Extract the release notes for the current version from `CHANGELOG.md`. It's a simple-and-crude shell script, but seems to work fine.
1. Create the actual Release with [actions/create-release](https://github.com/actions/create-release). This is the official action, but now unmaintained.
1. Upload the html and pdf file of the current version to the Release as assets with [actions/upload-release-asset](https://github.com/actions/upload-release-asset). This official action is unmaintained as well, unfortunately. Still, I prefer these because they are created by GitHub themselves.

- An example release can be seen here: https://github.com/iiroj/development-guidelines/releases/tag/1.9.0
- The associated action log can be seen here: https://github.com/iiroj/development-guidelines/runs/3503456555

Since the current workflow seems to be to build and commit release files into the source control, this Workflow doesn't do any building or validation itself. Thus it only runs on the semver tags and assumes those are created correctly.